### PR TITLE
py/persistentcode: Use a .mpy format that's backwards compatible

### DIFF
--- a/examples/modx/elftompy.py
+++ b/examples/modx/elftompy.py
@@ -10,15 +10,35 @@ This will make modx.mpy ready for importing.
 """
 
 import sys
+import struct
+
+def to_uint(n):
+    if n < 0:
+        raise ValueError('unsigned integer cannot be < 0')
+    b = bytearray()
+    while n:
+        # set high bit: more bytes will follow
+        b.insert(0, (n & 0x7f) | 0x80)
+        n >>= 7
+    if len(b) == 0:
+        return b'\x00'
+    # clear high bit: it's the last byte
+    b[-1] &= 0x7f
+    return bytes(b)
+
 
 def process_file(filename):
     with open(filename, 'rb') as f:
-        data = bytearray(f.read())
-    size = len(data) - 16
-    data[8] = size & 0xff
-    data[9] = size >> 8
+        header = f.read(4) # .mpy header + number of QSTRs
+        num_qstrs = struct.unpack('<H', f.read(2))[0]
+        padding = f.read(2) # skip
+        text = f.read()
+
     with open(filename, 'wb') as f:
-        f.write(data)
+        f.write(header)
+        f.write(to_uint(num_qstrs))
+        f.write(to_uint(len(text)))
+        f.write(text)
 
 if __name__ == '__main__':
     process_file(sys.argv[1])

--- a/py/persistnative.h
+++ b/py/persistnative.h
@@ -52,17 +52,15 @@
 // TODO: consolidate the first 4 bytes here with stuff in persistentcode.c
 #define MP_PERSISTENT_NATIVE_HEADER \
     __attribute__((section(".mpyheader"))) \
-    const byte header[16] = { \
+    const byte header[8] = { \
         'M', \
         2, \
         ((MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) << 0) \
-            | ((MICROPY_PY_BUILTINS_STR_UNICODE) << 1), \
-        16, \
-        MP_CODE_PERSISTENT_NATIVE, \
+            | ((MICROPY_PY_BUILTINS_STR_UNICODE) << 1) \
+            | (1 << 7),  \
         MP_PERSISTENT_ARCH_CURRENT, \
         (MP_LOCAL_QSTR_number_of & 0xff), (MP_LOCAL_QSTR_number_of >> 8), \
-        0, 0, /* size of text section, to be patched later */ \
-        0, 0, 0, 0, 0, 0, /* padding */ \
+        0, 0, /* padding */ \
     };
 
 #define MP_PERSISTENT_NATIVE_INIT \

--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -426,9 +426,6 @@ def read_bytecode_qstrs(file, bytecode, ip):
         ip += sz
 
 def read_raw_code(f):
-    code_type = f.read(1)[0]
-    if code_type != 2: # must be bytecode
-        raise Exception('unsupported code type: %u' % code_type)
     bc_len = read_uint(f)
     bytecode = bytearray(f.read(bc_len))
     ip, ip2, prelude = extract_prelude(bytecode)


### PR DESCRIPTION
This is a slightly different file format, compatible with current .mpy files (previously this branch would break compatibility). Also fixed build errors related to the file format, so it actually builds now.

Tested with the modx example, it works.