### PR TITLE
Load qstrs separately in load_raw_code_native

### DIFF
--- a/examples/modx/modx.c
+++ b/examples/modx/modx.c
@@ -14,6 +14,17 @@ enum {
     MP_LOCAL_QSTR_number_of,
 };
 
+__attribute__((section(".qstr")))
+struct {
+    #define QDEF(id, str) const char id[sizeof(str)];
+    QSTR_DEFINES
+    #undef QDEF
+} QSTR_VALUE = {
+    #define QDEF(id, str) str,
+    QSTR_DEFINES
+    #undef QDEF
+};
+
 STATIC mp_obj_t modx_add1(CONTEXT mp_obj_t x) {
     return RT(mp_binary_op)(MP_BINARY_OP_ADD, x, MP_OBJ_NEW_SMALL_INT(1));
 }
@@ -34,14 +45,6 @@ MP_PERSISTENT_NATIVE_HEADER
 
 MP_PERSISTENT_NATIVE_INIT
 void init(CONTEXT_ALONE) {
-    // create qstrs
-    {
-        qstr *q = pnd->qstr_table;
-        #define QDEF(id, str) *q++ = RT(qstr_from_str)(str);
-        QSTR_DEFINES
-        #undef QDEF
-    }
-
     // constants
     RT(mp_store_global)(QSTR(VAL1), CONST(_true));
     RT(mp_store_global)(QSTR(VAL2), MP_OBJ_NEW_SMALL_INT(123));

--- a/examples/modx/persistnative.ld
+++ b/examples/modx/persistnative.ld
@@ -8,6 +8,11 @@ SECTIONS
     {
         . = ALIGN(4);
         KEEP(*(.mpyheader))
+        QUAD(_qstr_end - _qstr_start)
+        _qstr_start = .;
+        KEEP(*(.qstr))
+        _qstr_end = .;
+        . = ALIGN(8);
         KEEP(*(.mpytext))
         *(.text*)
         *(.rodata*)

--- a/py/emitglue.h
+++ b/py/emitglue.h
@@ -47,7 +47,7 @@ typedef struct _mp_persistent_native_data_t {
     void *data;
 } mp_persistent_native_data_t;
 
-mp_persistent_native_data_t *mp_new_persistent_native_data(size_t num_qstrs);
+mp_persistent_native_data_t *mp_new_persistent_native_data(qstr *qstr_table);
 #endif
 
 typedef struct _mp_raw_code_t {

--- a/py/nativeglue.c
+++ b/py/nativeglue.c
@@ -184,10 +184,10 @@ const void *const mp_fun_table[MP_F_NUMBER_OF] = {
 };
 
 #if MICROPY_PERSISTENT_NATIVE
-mp_persistent_native_data_t *mp_new_persistent_native_data(size_t num_qstrs) {
+mp_persistent_native_data_t *mp_new_persistent_native_data(qstr *qstr_table) {
     mp_persistent_native_data_t *data = m_new_obj(mp_persistent_native_data_t);
     data->fun_table = mp_fun_table;
-    data->qstr_table = m_new0(qstr, num_qstrs);
+    data->qstr_table = qstr_table;
     data->data = NULL;
     return data;
 }

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -217,7 +217,14 @@ mp_raw_code_t *load_raw_code_native(mp_reader_t *reader) {
     if (arch != MP_PERSISTENT_ARCH_CURRENT) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, ".mpy has wrong arch"));
     }
+
+    // load qstrs
     uint num_qstrs = read_uint(reader);
+    qstr *qstr_table = m_new0(qstr, num_qstrs);
+    qstr *q = qstr_table;
+    for (size_t i=0; i<num_qstrs; i++) {
+        *q++ = load_qstr(reader);
+    }
 
     // load machine code
     mp_uint_t len = read_uint(reader);
@@ -226,7 +233,7 @@ mp_raw_code_t *load_raw_code_native(mp_reader_t *reader) {
     MP_PLAT_ALLOC_EXEC(len, &data, &alloc);
     read_bytes(reader, data, len);
 
-    mp_persistent_native_data_t *per_nat_data = mp_new_persistent_native_data(num_qstrs);
+    mp_persistent_native_data_t *per_nat_data = mp_new_persistent_native_data(qstr_table);
 
     // create raw_code and return it
     mp_raw_code_t *rc = mp_emit_glue_new_raw_code();

--- a/py/persistentcode.c
+++ b/py/persistentcode.c
@@ -213,15 +213,14 @@ STATIC mp_raw_code_t *load_raw_code_bytecode(mp_reader_t *reader) {
 
 #if MICROPY_PERSISTENT_NATIVE
 mp_raw_code_t *load_raw_code_native(mp_reader_t *reader) {
-    byte header[11];
-    read_bytes(reader, header, 11);
-    if (header[0] != MP_PERSISTENT_ARCH_CURRENT) {
+    byte arch = reader->readbyte(reader->data);
+    if (arch != MP_PERSISTENT_ARCH_CURRENT) {
         nlr_raise(mp_obj_new_exception_msg(&mp_type_ValueError, ".mpy has wrong arch"));
     }
-    uint num_qstrs = header[1] | (header[2] << 8);
+    uint num_qstrs = read_uint(reader);
 
     // load machine code
-    mp_uint_t len = header[3] | (header[4] << 8);
+    mp_uint_t len = read_uint(reader);
     void *data;
     size_t alloc;
     MP_PLAT_ALLOC_EXEC(len, &data, &alloc);

--- a/py/persistnative.h
+++ b/py/persistnative.h
@@ -52,7 +52,7 @@
 // TODO: consolidate the first 4 bytes here with stuff in persistentcode.c
 #define MP_PERSISTENT_NATIVE_HEADER \
     __attribute__((section(".mpyheader"))) \
-    const byte header[16] = { \
+    const byte header[8] = { \
         'M', \
         2, \
         ((MICROPY_OPT_CACHE_MAP_LOOKUP_IN_BYTECODE) << 0) \
@@ -61,8 +61,6 @@
         MP_CODE_PERSISTENT_NATIVE, \
         MP_PERSISTENT_ARCH_CURRENT, \
         (MP_LOCAL_QSTR_number_of & 0xff), (MP_LOCAL_QSTR_number_of >> 8), \
-        0, 0, /* size of text section, to be patched later */ \
-        0, 0, 0, 0, 0, 0, /* padding */ \
     };
 
 #define MP_PERSISTENT_NATIVE_INIT \


### PR DESCRIPTION
Do not load qstrs from within the init function, but put them in a separate area of the .mpy file (with a more efficient encoding). This reduces the size of the .mpy file (94 bytes in the modx example), but increases the code size by 20 bytes on a Cortex-M0. I've also done another optimization which reduces code size by 16 bytes (net increase is thus 4 bytes).