### PR TITLE
Spiflash large chip support

### DIFF
--- a/drivers/bus/qspi.h
+++ b/drivers/bus/qspi.h
@@ -38,9 +38,9 @@ enum {
 typedef struct _mp_qspi_proto_t {
     int (*ioctl)(void *self, uint32_t cmd);
     void (*write_cmd_data)(void *self, uint8_t cmd, size_t len, uint32_t data);
-    void (*write_cmd_addr_data)(void *self, uint8_t cmd, uint32_t addr, size_t len, const uint8_t *src);
+    void (*write_cmd_addr_data)(void *self, uint8_t cmd, uint32_t addr, uint8_t addr_bytes, size_t len, const uint8_t *src);
     uint32_t (*read_cmd)(void *self, uint8_t cmd, size_t len);
-    void (*read_cmd_qaddr_qdata)(void *self, uint8_t cmd, uint32_t addr, size_t len, uint8_t *dest);
+    void (*read_cmd_qaddr_qdata)(void *self, uint8_t cmd, uint32_t addr, uint8_t addr_bytes, size_t len, uint8_t *dest);
 } mp_qspi_proto_t;
 
 typedef struct _mp_soft_qspi_obj_t {

--- a/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF2/mpconfigboard.h
@@ -55,8 +55,8 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_BDEV_READBLOCKS(dest, bl, n) spi_bdev_readblocks(&spi_bdev, (dest), (bl), (n))
 #define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) spi_bdev_writeblocks(&spi_bdev, (src), (bl), (n))
 
-// additional SPI flash, to be memory mapped
-#define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (24)
+// additional 2MB SPI flash, to be memory mapped
+#define MICROPY_HW_QSPIFLASH_SIZE_BYTES (2*1024*1024)
 #define MICROPY_HW_QSPIFLASH_CS     (pyb_pin_QSPI_CS)
 #define MICROPY_HW_QSPIFLASH_SCK    (pyb_pin_QSPI_CLK)
 #define MICROPY_HW_QSPIFLASH_IO0    (pyb_pin_QSPI_D0)
@@ -69,7 +69,7 @@ extern const struct _mp_spiflash_config_t spiflash2_config;
 extern struct _spi_bdev_t spi_bdev2;
 #if 0
 #define MICROPY_HW_BDEV2_IOCTL(op, arg) ( \
-    (op) == BDEV_IOCTL_NUM_BLOCKS ? ((1 << (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3)) / FLASH_BLOCK_SIZE) : \
+    (op) == BDEV_IOCTL_NUM_BLOCKS ? (MICROPY_HW_QSPIFLASH_SIZE_BYTES / FLASH_BLOCK_SIZE) : \
     (op) == BDEV_IOCTL_INIT ? spi_bdev_ioctl(&spi_bdev2, (op), (uint32_t)&spiflash2_config) : \
     spi_bdev_ioctl(&spi_bdev2, (op), (arg)) \
 )

--- a/ports/stm32/boards/PYBD_SF3/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF3/mpconfigboard.h
@@ -55,8 +55,8 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_BDEV_READBLOCKS(dest, bl, n) spi_bdev_readblocks(&spi_bdev, (dest), (bl), (n))
 #define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) spi_bdev_writeblocks(&spi_bdev, (src), (bl), (n))
 
-// additional SPI flash, to be memory mapped
-#define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (24)
+// additional 2MB SPI flash, to be memory mapped
+#define MICROPY_HW_QSPIFLASH_SIZE_BYTES (2*1024*1024)
 #define MICROPY_HW_QSPIFLASH_CS     (pyb_pin_QSPI_CS)
 #define MICROPY_HW_QSPIFLASH_SCK    (pyb_pin_QSPI_CLK)
 #define MICROPY_HW_QSPIFLASH_IO0    (pyb_pin_QSPI_D0)
@@ -69,7 +69,7 @@ extern const struct _mp_spiflash_config_t spiflash2_config;
 extern struct _spi_bdev_t spi_bdev2;
 #if 0
 #define MICROPY_HW_BDEV2_IOCTL(op, arg) ( \
-    (op) == BDEV_IOCTL_NUM_BLOCKS ? ((1 << (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3)) / FLASH_BLOCK_SIZE) : \
+    (op) == BDEV_IOCTL_NUM_BLOCKS ? (MICROPY_HW_QSPIFLASH_SIZE_BYTES / FLASH_BLOCK_SIZE) : \
     (op) == BDEV_IOCTL_INIT ? spi_bdev_ioctl(&spi_bdev2, (op), (uint32_t)&spiflash2_config) : \
     spi_bdev_ioctl(&spi_bdev2, (op), (arg)) \
 )

--- a/ports/stm32/boards/PYBD_SF6/mpconfigboard.h
+++ b/ports/stm32/boards/PYBD_SF6/mpconfigboard.h
@@ -56,7 +56,7 @@ extern struct _spi_bdev_t spi_bdev;
 #define MICROPY_HW_BDEV_WRITEBLOCKS(src, bl, n) spi_bdev_writeblocks(&spi_bdev, (src), (bl), (n))
 
 // additional SPI flash, to be memory mapped
-#define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (24)
+#define MICROPY_HW_QSPIFLASH_SIZE_BYTES (2*1024*1024)
 #define MICROPY_HW_QSPIFLASH_CS     (pyb_pin_QSPI_CS)
 #define MICROPY_HW_QSPIFLASH_SCK    (pyb_pin_QSPI_CLK)
 #define MICROPY_HW_QSPIFLASH_IO0    (pyb_pin_QSPI_D0)
@@ -69,7 +69,7 @@ extern const struct _mp_spiflash_config_t spiflash2_config;
 extern struct _spi_bdev_t spi_bdev2;
 #if 0
 #define MICROPY_HW_BDEV2_IOCTL(op, arg) ( \
-    (op) == BDEV_IOCTL_NUM_BLOCKS ? ((1 << (MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 - 3)) / FLASH_BLOCK_SIZE) : \
+    (op) == BDEV_IOCTL_NUM_BLOCKS ? (MICROPY_HW_QSPIFLASH_SIZE_BYTES / FLASH_BLOCK_SIZE) : \
     (op) == BDEV_IOCTL_INIT ? spi_bdev_ioctl(&spi_bdev2, (op), (uint32_t)&spiflash2_config) : \
     spi_bdev_ioctl(&spi_bdev2, (op), (arg)) \
 )

--- a/ports/stm32/boards/STM32F769DISC/mpconfigboard.h
+++ b/ports/stm32/boards/STM32F769DISC/mpconfigboard.h
@@ -27,7 +27,7 @@ void board_early_init(void);
 #define MICROPY_HW_FLASH_LATENCY    FLASH_LATENCY_7 // 210-216 MHz needs 7 wait states
 
 // 512MBit external QSPI flash, to be memory mapped
-#define MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2 (29)
+#define MICROPY_HW_QSPIFLASH_SIZE_BYTES (64*1024*1024)
 #define MICROPY_HW_QSPIFLASH_CS     (pin_B6)
 #define MICROPY_HW_QSPIFLASH_SCK    (pin_B2)
 #define MICROPY_HW_QSPIFLASH_IO0    (pin_C9)

--- a/ports/stm32/powerctrl.c
+++ b/ports/stm32/powerctrl.c
@@ -277,7 +277,7 @@ void powerctrl_enter_stop_mode(void) {
     // executed until after the clocks are reconfigured
     uint32_t irq_state = disable_irq();
 
-    #if defined(MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2)
+    #if defined(MICROPY_HW_QSPIFLASH_SIZE_BYTES)
     mp_spiflash_deepsleep(&spi_bdev.spiflash, 1);
     mp_spiflash_deepsleep(&spi_bdev2.spiflash, 1);
     #endif
@@ -361,7 +361,7 @@ void powerctrl_enter_stop_mode(void) {
 
     #endif
 
-    #if defined(MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2)
+    #if defined(MICROPY_HW_QSPIFLASH_SIZE_BYTES)
     qspi_init();
     #if 1
     mp_spiflash_deepsleep(&spi_bdev.spiflash, 0);
@@ -375,7 +375,7 @@ void powerctrl_enter_stop_mode(void) {
 }
 
 void powerctrl_enter_standby_mode(void) {
-    #if defined(MICROPY_HW_QSPIFLASH_SIZE_BITS_LOG2)
+    #if defined(MICROPY_HW_QSPIFLASH_SIZE_BYTES)
     // TODO need proper configuration option to select this
     // or maybe a bdev ioctl to do it
     mp_spiflash_deepsleep(&spi_bdev.spiflash, 1);


### PR DESCRIPTION
Note: This is currently sitting on top of #4669 so is likely to need rebasing, but it builds on top of spiflash updates in that branch so doesn't really target current master.

This PR provides support for (Q)SPI flash flash chips over 16MB / 128Mbit where 32bit addressing is required for the higher address ranges.

It also includes support for defining flash chip size in bytes in mpconfigboard rather than the log2 bit width currently needed by the stm drivers. I find this far more user friendly, but open to discussion.

There is also some minor reworking to the MPU configuration, again I'm very open to further discussion along these lines.
I have not yet tested this change with memory map enabled or with the mpu caching enabled (as configurable in new defines).

The first commit resolves #4609